### PR TITLE
Proposal for XFH configuration.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "argo-url-helper",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "A URL helper for formatting and manipulating paths in Argo.",
   "main": "url.js",
   "scripts": {

--- a/url.js
+++ b/url.js
@@ -1,60 +1,87 @@
 var path = require('path');
 var url = require('url');
 
-module.exports = function(handle) {
-  handle('request', function(env, next) {
-    var uri = parseUri(env);
-
-    env.helpers = env.helpers || {};
-    env.helpers.url = {};
-
-    env.helpers.url.join = function(pathname) {
-      var parsed = url.parse(uri);
-      parsed.search = null;
-      parsed.pathname = path.join(parsed.pathname, pathname).replace(/\\/g, '/');
-      
-      return url.format(parsed);
-    };
-
-    env.helpers.url.path = function(pathname) {
-      var parsed = url.parse(uri);
-      parsed.search = null;
-      parsed.pathname = pathname;
-
-      return url.format(parsed);
-    };
-
-    env.helpers.url.current = function() {
-      return uri;
-    };
-
-    next(env);
-  });
-};
-
-function parseUri(env) {
-  var xfp = env.request.headers['x-forwarded-proto'];
-  var xfh = env.request.headers['x-forwarded-host'];
-  var protocol;
-
-  if (xfp && xfp.length) {
-    protocol = xfp.replace(/\s*/, '').split(',')[0];
-  } else {
-    protocol = env.request.connection.encrypted ? 'https' : 'http';
+module.exports =function(opts) {
+  var useXForwardedHostHeader = true;
+  if(opts && typeof opts.useXForwardedHostHeader !== 'undefined') {
+    useXForwardedHostHeader = opts.useXForwardedHostHeader;
   }
+  return function(handle) {
+    handle('request', function(env, next) {
+      env.helpers = env.helpers || {};
+      env.helpers.url = {};
 
-  var host = xfh || env.request.headers['host'];
+      var uri = parseUri(env);
 
-  if (!host) {
-    var address = env.request.connection.address();
-    host = address.address;
-    if (address.port) {
-      if (!(protocol === 'https' && address.port === 443) && 
-          !(protocol === 'http' && address.port === 80)) {
-        host += ':' + address.port
+      
+      env.helpers.url.join = function(pathname, env) {
+        var uri = uri;
+        if(env) {
+          uri =  parseUri(env) 
+        }
+        var parsed = url.parse(uri);
+        parsed.search = null;
+        parsed.pathname = path.join(parsed.pathname, pathname).replace(/\\/g, '/');
+        
+        return url.format(parsed);
+      };
+
+      env.helpers.url.path = function(pathname, env) {
+        var uri = uri;
+        if(env) {
+          uri =  parseUri(env) 
+        }         
+        var parsed = url.parse(uri);
+        parsed.search = null;
+        parsed.pathname = pathname;
+
+        return url.format(parsed);
+      };
+
+      env.helpers.url.current = function(env) {
+        if(env) {
+          return parseUri(env) 
+        } else {
+          return uri;
+        }
+      };
+
+      next(env);
+    });
+  };
+
+  function parseUri(env) {
+    var xfp = env.request.headers['x-forwarded-proto'];
+    var xfh = env.request.headers['x-forwarded-host'];
+    var useXfh = useXForwardedHostHeader;
+    if(env.helpers.url && typeof env.helpers.url.useXForwardedHostHeader !== 'undefined') {
+      useXfh = env.helpers.url.useXForwardedHostHeader;
+    }
+    var protocol;
+
+    if (xfp && xfp.length) {
+      protocol = xfp.replace(/\s*/, '').split(',')[0];
+    } else {
+      protocol = env.request.connection.encrypted ? 'https' : 'http';
+    }
+
+    var host = env.request.headers['host'];
+
+    if(useXfh && xfh) {
+      host = xfh;
+    }
+
+    if (!host) {
+      var address = env.request.connection.address();
+      host = address.address;
+      if (address.port) {
+        if (!(protocol === 'https' && address.port === 443) && 
+            !(protocol === 'http' && address.port === 80)) {
+          host += ':' + address.port
+        }
       }
     }
-  }
 
-  return protocol + '://' + path.join(host, env.request.url);
-}
+    return protocol + '://' + path.join(host, env.request.url);
+  }
+} 

--- a/url.js
+++ b/url.js
@@ -2,7 +2,7 @@ var path = require('path');
 var url = require('url');
 
 module.exports =function(opts) {
-  var useXForwardedHostHeader = true;
+  var useXForwardedHostHeader = false;
   if(opts && typeof opts.useXForwardedHostHeader !== 'undefined') {
     useXForwardedHostHeader = opts.useXForwardedHostHeader;
   }
@@ -14,10 +14,10 @@ module.exports =function(opts) {
       var uri = parseUri(env);
 
       
-      env.helpers.url.join = function(pathname, env) {
+      env.helpers.url.join = function(pathname, opts) {
         var uri = uri;
-        if(env) {
-          uri =  parseUri(env) 
+        if(opts) {
+          uri =  parseUri(env, opts) 
         }
         var parsed = url.parse(uri);
         parsed.search = null;
@@ -26,10 +26,10 @@ module.exports =function(opts) {
         return url.format(parsed);
       };
 
-      env.helpers.url.path = function(pathname, env) {
+      env.helpers.url.path = function(pathname, opts) {
         var uri = uri;
-        if(env) {
-          uri =  parseUri(env) 
+        if(opts) {
+          uri =  parseUri(env, opts) 
         }         
         var parsed = url.parse(uri);
         parsed.search = null;
@@ -38,9 +38,9 @@ module.exports =function(opts) {
         return url.format(parsed);
       };
 
-      env.helpers.url.current = function(env) {
-        if(env) {
-          return parseUri(env) 
+      env.helpers.url.current = function(opts) {
+        if(opts) {
+          return parseUri(env, opts) 
         } else {
           return uri;
         }
@@ -50,13 +50,14 @@ module.exports =function(opts) {
     });
   };
 
-  function parseUri(env) {
+  function parseUri(env, opts) {
     var xfp = env.request.headers['x-forwarded-proto'];
     var xfh = env.request.headers['x-forwarded-host'];
     var useXfh = useXForwardedHostHeader;
-    if(env.helpers.url && typeof env.helpers.url.useXForwardedHostHeader !== 'undefined') {
-      useXfh = env.helpers.url.useXForwardedHostHeader;
+    if(opts && typeof opts.useXForwardedHostHeader !== 'undefined') {
+      useXfh = opts.useXForwardedHostHeader; 
     }
+    
     var protocol;
 
     if (xfp && xfp.length) {


### PR DESCRIPTION
Here is the proposal for the `x-forwarded-host` configuration.

Method 1: Calling with an options object

```
argo()
  .use(urlHelper({ useXForwardedHostHeader: true })
  .listen(1337);
```

Method 2: Setting a parameter on env. Note this would trump the global configuration if set in Method 1.

```
argo()
  .use(urlHelper())
  .use(function(handle) {
    handle('request', function(env, next) {
      env.helpers.url.useXForwardedHostHeader = true;
      env.response.statusCode = 200;
      env.response.body = env.helpers.url.current(env);
      next(env);
    });
  })
```

The argo pipeline is setup in a way that the middleware processing for the url helper would come before any user segments in the pipeline. That is why method 2 requires you to provide env to the function.

Thoughts?
