### PR TITLE
Add "X-Forwarded-Path" Header

### DIFF
--- a/url.js
+++ b/url.js
@@ -7,9 +7,9 @@ module.exports =function(opts) {
     useXForwardedHostHeader = opts.useXForwardedHostHeader;
   }
 
-  var useXForwardedRootHeader = false;
-  if(opts && typeof opts.useXForwardedRootHeader !== 'undefined') {
-    useXForwardedRootHeader = opts.useXForwardedRootHeader;
+  var useXForwardedPathHeader = false;
+  if(opts && typeof opts.useXForwardedPathHeader !== 'undefined') {
+    useXForwardedPathHeader = opts.useXForwardedPathHeader;
   }
 
   return function(handle) {
@@ -98,15 +98,15 @@ module.exports =function(opts) {
       pathname = env.request.url;
     }
 
-    var xfr = env.request.headers['x-forwarded-root'];
-    var useXfr = useXForwardedRootHeader;
-    if(opts && typeof opts.useXForwardedRootHeader != 'undefined') {
-      useXfr = options.useXForwardedRootHeader;
+    var xfPath = env.request.headers['x-forwarded-path'];
+    var useXFPath = useXForwardedPathHeader;
+    if(opts && typeof opts.useXForwardedPathHeader != 'undefined') {
+      useXFPath = options.useXForwardedPathHeader;
     }
 
     var root = '';
-    if (useXfr && xfr) {
-      root = xfr;
+    if (useXFPath && xfPath) {
+      root = xfPath;
     }
 
     return path.join(root, pathname);

--- a/url.js
+++ b/url.js
@@ -22,7 +22,7 @@ module.exports =function(opts) {
       env.helpers.url.join = function(pathname, opts) {
         var tmpUri = uri;
         if(opts) {
-          tmpUri =  parseUri(env, opts)
+          tmpUri =  parseUri(env, opts);
         }
         var parsed = url.parse(tmpUri);
         parsed.search = null;
@@ -34,7 +34,7 @@ module.exports =function(opts) {
       env.helpers.url.path = function(pathname, opts) {
         var tmpUri = uri;
         if(opts) {
-          tmpUri =  parseUri(env, opts)
+          tmpUri =  parseUri(env, opts);
         }
         var parsed = url.parse(tmpUri);
         parsed.search = null;
@@ -45,7 +45,7 @@ module.exports =function(opts) {
 
       env.helpers.url.current = function(opts) {
         if(opts) {
-          return parseUri(env, opts)
+          return parseUri(env, opts);
         } else {
           return uri;
         }

--- a/url.js
+++ b/url.js
@@ -38,7 +38,7 @@ module.exports =function(opts) {
         }
         var parsed = url.parse(tmpUri);
         parsed.search = null;
-        parsed.pathname = adjustPath(env, pathname, opts);
+        parsed.pathname = adjustPath(env, opts, pathname);
 
         return url.format(parsed);
       };
@@ -93,9 +93,8 @@ module.exports =function(opts) {
     return protocol + '://' + path.join(host, reqPath);
   }
 
-  function adjustPath(env, pathname, opts) {
+  function adjustPath(env, opts, pathname) {
     if(arguments.length == 2) {
-      opts = pathname;
       pathname = env.request.url;
     }
 


### PR DESCRIPTION
This update adds support for an "X-Forwarded-Root" header, which works
much the same as the "X-Forwarded-Host" header. The value provided will
be inserted in all `href` values as the root path.

For example:

```
> curl http://127.0.0.1:1337 -H 'X-Forwarded-Host: zetta.com' -H 'X-Forwarded-Root: api/v1'
"links": [
  {
    "rel": [
      "self"
    ],
    "href": "http://zetta.com/api/v1/"
  },
  {
    "title": "SEVERX",
    "rel": [
      "http://rels.zettajs.io/server"
    ],
    "href": "http://zetta.com/api/v1/servers/SEVERX"
  },
  {
    "rel": [
      "http://rels.zettajs.io/events"
    ],
    "href": "ws://zetta.com/api/v1/events"
  },
  {
    "rel": [
      "http://rels.zettajs.io/peer-management"
    ],
    "href": "http://zetta.com/api/v1/peer-management"
  }
],
```
